### PR TITLE
Fix classpath format and initial class path directory support

### DIFF
--- a/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPath.java
+++ b/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPath.java
@@ -71,13 +71,12 @@ public final class ClassPath {
         }
 
         public Builder add(JavaArchive archive) {
-            this.archive.add(archive, ROOT_ARCHIVE_PATH, ZipExporter.class);
-            return this;
+            return addArchive(archive);
         }
 
         public Builder add(JavaArchive... archives) {
             for (JavaArchive archive : archives) {
-                this.archive.add(archive, ROOT_ARCHIVE_PATH, ZipExporter.class);
+                addArchive(archive);
             }
             return this;
         }
@@ -89,6 +88,21 @@ public final class ClassPath {
 
         public Builder addSystemProperty(String key, String value) {
             this.systemProperties.setProperty(key, value);
+            return this;
+        }
+
+        /**
+         *
+         * @param name
+         * @return the builder used to construct a virtual class path directory
+         * @see ClassPathDirectory.Builder#buildAndUp()
+         */
+        public ClassPathDirectory.Builder addDirectory(String name) {
+            return ClassPathDirectory.builder(name, this);
+        }
+
+        Builder addArchive(Archive<?> archive) {
+            this.archive.add(archive, ROOT_ARCHIVE_PATH, ZipExporter.class);
             return this;
         }
 

--- a/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPathDirectory.java
+++ b/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPathDirectory.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.se.api;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ClassAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+
+/**
+ * Class path directory is represented as a {@link GenericArchive} instance.
+ *
+ * @author Martin Kouba
+ */
+public final class ClassPathDirectory {
+
+    private static final ArchivePath MARKER_FILE_ARCHIVE_PATH = ArchivePaths.create("META-INF/arquillian.se.container.ClassPathDirectory");
+
+    private ClassPathDirectory() {
+    }
+
+    /**
+     *
+     * @return a new instance of class path directory builder
+     */
+    static Builder builder(String name, ClassPath.Builder classPathBuilder) {
+        return new Builder(name, classPathBuilder);
+    }
+
+    /**
+     * A builder used to construct a virtual class path directory.
+     *
+     * @author Martin Kouba
+     */
+    public static final class Builder {
+
+        private final ClassPath.Builder classPathBuilder;
+
+        private final GenericArchive archive;
+
+        private Builder(String name, ClassPath.Builder classPathBuilder) {
+            this.classPathBuilder = classPathBuilder;
+            this.archive = ShrinkWrap.create(GenericArchive.class, name).add(EmptyAsset.INSTANCE, MARKER_FILE_ARCHIVE_PATH);
+        }
+
+        public Builder addClass(Class<?> clazz) {
+            archive.add(new ClassAsset(clazz), ClassPath.ROOT_ARCHIVE_PATH + clazz.getName());
+            return this;
+        }
+
+        public Builder addResource(Asset resource, String target) {
+            archive.add(resource, target);
+            return this;
+        }
+
+        /**
+         * Builds the virtual class path directory and returns the parent class path builder.
+         *
+         * @return the parent class path builder
+         */
+        public ClassPath.Builder buildAndUp() {
+            return classPathBuilder.addArchive(archive);
+        }
+
+    }
+
+    public static boolean isRepresentedBy(Archive<?> archive) {
+        return archive.contains(MARKER_FILE_ARCHIVE_PATH);
+    }
+
+}

--- a/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPathDirectory.java
+++ b/container-se-api/src/main/java/org/jboss/arquillian/container/se/api/ClassPathDirectory.java
@@ -86,4 +86,8 @@ public final class ClassPathDirectory {
         return archive.contains(MARKER_FILE_ARCHIVE_PATH);
     }
 
+    public static boolean isMarkerFileArchivePath(ArchivePath path) {
+        return path.equals(MARKER_FILE_ARCHIVE_PATH);
+    }
+
 }

--- a/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
+++ b/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
@@ -23,9 +23,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -224,11 +227,13 @@ public class ManagedSEDeployableContainer implements DeployableContainer<Managed
         command.add(javaHome.getAbsolutePath() + File.separator + "bin" + File.separator + "java");
         command.add("-cp");
         StringBuilder builder = new StringBuilder();
-        for (File materializedDeployment : materializedTestDeployments) {
-            builder.append(File.pathSeparator + TARGET + File.separator + materializedDeployment.getName());
-        }
-        for (File dependencyJar : dependenciesJars) {
-            builder.append(File.pathSeparator + dependencyJar.getPath());
+        Set<File> classPathEntries = new HashSet<>(materializedTestDeployments);
+        classPathEntries.addAll(dependenciesJars);
+        for (Iterator<File> iterator = classPathEntries.iterator(); iterator.hasNext();) {
+            builder.append(iterator.next().getPath());
+            if(iterator.hasNext()) {
+                builder.append(File.pathSeparator);
+            }
         }
         command.add(builder.toString());
         command.add("-Dcom.sun.management.jmxremote");

--- a/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
+++ b/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
@@ -299,6 +299,10 @@ public class ManagedSEDeployableContainer implements DeployableContainer<Managed
             if (child.getAsset() == null) {
                 materializeSubdirectories(entryDirectory, child);
             } else {
+                if (ClassPathDirectory.isMarkerFileArchivePath(child.getPath())) {
+                    // Do not materialize the marker file
+                    continue;
+                }
                 // E.g. META-INF/my-super-descriptor.xml
                 File resourceFile = new File(entryDirectory, child.getPath().get().replace(DELIMITER_RESOURCE_PATH, File.separatorChar));
                 File resoureDirectory = resourceFile.getParentFile();

--- a/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
+++ b/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEDeployableContainer.java
@@ -152,6 +152,9 @@ public class ManagedSEDeployableContainer implements DeployableContainer<Managed
     public ProtocolMetaData deploy(final Archive<?> archive) throws DeploymentException {
         LOGGER.info("Deploying " + archive.getName());
 
+        // First of all clear the list of previously materialized deployments - otherwise the class path would grow indefinitely
+        materializedTestDeployments.clear();
+
         if (ClassPath.isRepresentedBy(archive)) {
             for (Node child : archive.get(ClassPath.ROOT_ARCHIVE_PATH).getChildren()) {
                 if (child.getAsset() instanceof ArchiveAsset) {

--- a/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/ClassPathDirectoryResourceTest.java
+++ b/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/ClassPathDirectoryResourceTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.se.test.directory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ClassPathDirectoryResourceTest {
+
+    private static final String RESOURCE_NAME = "META-INF/my-super-descriptor.xml";
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(JavaArchive.class).addClass(ClassPathDirectoryResourceTest.class)).addDirectory("test-dir")
+                .addResource(new StringAsset("hello"), RESOURCE_NAME).buildAndUp().build();
+    }
+
+    @Test
+    public void testResourceFound() throws IOException {
+        URL resourceUrl = this.getClass().getClassLoader().getResource(RESOURCE_NAME);
+        assertNotNull(resourceUrl);
+        StringWriter writer = new StringWriter();
+        try (InputStream in = resourceUrl.openStream()) {
+            copy(new InputStreamReader(in), writer);
+        }
+        assertEquals("hello", writer.toString());
+    }
+
+    private void copy(Reader in, Writer out) throws IOException {
+        final char[] buffer = new char[8192];
+        int n = 0;
+        while (-1 != (n = in.read(buffer))) {
+            out.write(buffer, 0, n);
+        }
+        out.flush();
+    }
+
+}

--- a/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/ClassPathDirectoryTest.java
+++ b/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/ClassPathDirectoryTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.se.test.directory;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ClassPathDirectoryTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(JavaArchive.class).addClass(ClassPathDirectoryTest.class)).addDirectory("test-dir")
+                .addClass(FooFromDirClassPathEntry.class).buildAndUp().build();
+    }
+
+    @Test
+    public void testClassFound() {
+        FooFromDirClassPathEntry foo = new FooFromDirClassPathEntry();
+        assertEquals(1, foo.ping());
+    }
+
+}

--- a/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/FooFromDirClassPathEntry.java
+++ b/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/directory/FooFromDirClassPathEntry.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.se.test.directory;
+
+public class FooFromDirClassPathEntry {
+
+    public int ping() {
+        return 1;
+    }
+}

--- a/container-se-tests/src/test/resources/arquillian.xml
+++ b/container-se-tests/src/test/resources/arquillian.xml
@@ -7,6 +7,9 @@
       <protocol type="simple-jmx" />
       <configuration>
          <property name="additionalJavaOpts">-Dtest.foo=false</property>
+         <property name="logLevel">INFO</property>
+         <property name="debug">false</property>
+         <property name="keepDeploymentArchives">false</property>
       </configuration>
    </container>
 


### PR DESCRIPTION
- path separator should only be used to separate entries, currently the
classpath always starts with the separator